### PR TITLE
common: update readme installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [node.js](https://github.com/asdf-vm/asdf-nodejs)
 - [pnpm](https://pnpm.io/installation)
 - react-native [dependencies per platform](https://reactnative.dev/docs/environment-setup?guide=native)
+- [foundry](https://getfoundry.sh/introduction/installation): Needed for contracts package
 
 #### install
 


### PR DESCRIPTION
### Description

* Issue:  If foundry is not installed in a fresh clean install, the hooks will fail when building the app in first ```pnpm install``` command.  It will try to run forge build in contracts package and it will fail. 