### PR TITLE
🥅 server: fingerprint service errors by name and message

### DIFF
--- a/.changeset/bright-falcon-dance.md
+++ b/.changeset/bright-falcon-dance.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 fingerprint service errors by name and message


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

replaces complex error message parsing logic with clean `ServiceError` type checking for sentry fingerprinting. the old approach parsed error messages to extract http status codes and json payloads (splitting on "Error:", regex matching status codes, json parsing). the new approach uses `ServiceError.name` and `ServiceError.message` directly when available, and falls back to generic fingerprinting for any error with a `status` property in `instrument.cjs`.

- removed 27 lines of string manipulation logic in `server/index.ts`
- added simple instanceof check for `ServiceError` 
- added `beforeSend` hook in `instrument.cjs` to fingerprint errors with `status` property using `error.name` and `error.message`
- renamed `error` to `revert` in the contract error handling loop to avoid variable shadowing

<h3>Confidence Score: 5/5</h3>

- safe to merge with no risk
- simplifies error handling by removing fragile string parsing and using type-safe checks instead. the change is well-tested (ServiceError has comprehensive test coverage), reduces complexity significantly, and maintains backward compatibility by keeping undefined fingerprint for non-service errors
- no files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .changeset/bright-falcon-dance.md | adds changeset for patch release with correct emoji and lowercase format |
| server/index.ts | replaces complex string parsing with simple `ServiceError` instance check for error fingerprinting |
| server/instrument.cjs | adds generic error fingerprinting for errors with `status` property, renames variable to avoid shadowing |

</details>



<sub>Last reviewed commit: 6e7a38e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error tracking and identification for service errors, improving debugging and error reporting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->