### PR TITLE
✨ server: support offramp transfer reference

### DIFF
--- a/.changeset/quick-lions-attack.md
+++ b/.changeset/quick-lions-attack.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+✨ support offramp transfer reference

--- a/.changeset/swift-badgers-cheer.md
+++ b/.changeset/swift-badgers-cheer.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+♻️ create offramp transfer on external account

--- a/server/api/ramp.ts
+++ b/server/api/ramp.ts
@@ -44,6 +44,7 @@ const ErrorCodes = {
   NOT_APPROVED: "not approved",
   NOT_STARTED: "not started",
   POSTAL_CODE_REQUIRED: "postal code required",
+  TRANSFER_NOT_FOUND: "transfer not found",
   WITHDRAWAL_IN_PROGRESS: "withdrawal in progress",
 };
 
@@ -259,6 +260,9 @@ export default new Hono()
               if (error instanceof Error && error.message === bridge.ErrorCodes.EXTERNAL_ACCOUNT_CURRENCY_MISMATCH) {
                 return c.json({ code: ErrorCodes.EXTERNAL_ACCOUNT_CURRENCY_MISMATCH }, 400);
               }
+              if (error instanceof Error && error.message === bridge.ErrorCodes.OFFRAMP_TRANSFER_NOT_FOUND) {
+                return c.json({ code: ErrorCodes.TRANSFER_NOT_FOUND }, 400);
+              }
               if (error instanceof Error && error.message === bridge.ErrorCodes.TRANSFER_IN_USE) {
                 return c.json({ code: ErrorCodes.WITHDRAWAL_IN_PROGRESS }, 400);
               }
@@ -379,7 +383,14 @@ export default new Hono()
     if (bridgeUser.status !== "active") return c.json({ code: ErrorCodes.NOT_APPROVED }, 400);
 
     try {
-      return c.json(await bridge.createExternalAccount(bridgeUser, c.req.valid("json")), 200);
+      const externalAccount = await bridge.createExternalAccount(bridgeUser, c.req.valid("json"));
+      await bridge.createOfframpTransfer(
+        bridgeUser.id,
+        credential.account,
+        externalAccount.id,
+        externalAccount.currency,
+      );
+      return c.json(externalAccount, 200);
     } catch (error) {
       if (error instanceof Error && error.message === bridge.ErrorCodes.NO_ENDORSEMENT) {
         return c.json({ code: ErrorCodes.NOT_APPROVED }, 400);

--- a/server/api/ramp.ts
+++ b/server/api/ramp.ts
@@ -382,13 +382,16 @@ export default new Hono()
     if (!bridgeUser) return c.json({ code: ErrorCodes.NOT_STARTED }, 400);
     if (bridgeUser.status !== "active") return c.json({ code: ErrorCodes.NOT_APPROVED }, 400);
 
+    const payload = c.req.valid("json");
     try {
-      const externalAccount = await bridge.createExternalAccount(bridgeUser, c.req.valid("json"));
+      const externalAccount = await bridge.createExternalAccount(bridgeUser, payload);
       await bridge.createOfframpTransfer(
         bridgeUser.id,
         credential.account,
         externalAccount.id,
         externalAccount.currency,
+        payload.currency === "USD" ? payload.rail : undefined,
+        payload.reference,
       );
       return c.json(externalAccount, 200);
     } catch (error) {
@@ -588,6 +591,8 @@ const RampResponse = object({
         address: Address,
         fee: string(),
         estimatedProcessingTime: string(),
+        rail: optional(picklist(["ach", "wire"])),
+        reference: optional(string()),
       }),
       object({
         network: literal("TRON"),

--- a/server/test/api/ramp.test.ts
+++ b/server/test/api/ramp.test.ts
@@ -745,6 +745,29 @@ describe("ramp api", () => {
           await expect(response.json()).resolves.toStrictEqual({ code: "external account not found" });
         });
 
+        it("returns 400 when the offramp transfer is not found", async () => {
+          vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+          vi.spyOn(bridge, "getQuote").mockResolvedValue({ buyRate: "1.00", sellRate: "1.00" });
+          vi.spyOn(bridge, "getOfframpDepositDetails").mockRejectedValue(
+            new Error(bridge.ErrorCodes.OFFRAMP_TRANSFER_NOT_FOUND),
+          );
+
+          const response = await appClient.quote.$get(
+            {
+              query: {
+                provider: "bridge",
+                currency: "USD",
+                direction: "offramp",
+                externalAccountId: "ext-acc-1",
+              },
+            },
+            { headers: { "test-credential-id": "ramp-bridge" } },
+          );
+
+          expect(response.status).toBe(400);
+          await expect(response.json()).resolves.toStrictEqual({ code: "transfer not found" });
+        });
+
         it("returns 500 when bridge util throws an unexpected error", async () => {
           vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
           vi.spyOn(bridge, "getQuote").mockResolvedValue({ buyRate: "1.00", sellRate: "1.00" });
@@ -1369,9 +1392,10 @@ describe("ramp api", () => {
       expect(response.status).toBe(500);
     });
 
-    it("delegates to createExternalAccount and returns the external account", async () => {
+    it("creates the external account and its offramp transfer, then returns the external account", async () => {
       vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
       const createSpy = vi.spyOn(bridge, "createExternalAccount").mockResolvedValue(externalAccount);
+      const transferSpy = vi.spyOn(bridge, "createOfframpTransfer").mockResolvedValue(undefined as never);
 
       const response = await appClient["external-account"].$post(
         { json: input },
@@ -1381,6 +1405,25 @@ describe("ramp api", () => {
       expect(response.status).toBe(200);
       await expect(response.json()).resolves.toStrictEqual(externalAccount);
       expect(createSpy).toHaveBeenCalledWith(bridgeCustomer, input);
+      expect(transferSpy).toHaveBeenCalledWith(
+        bridgeCustomer.id,
+        deriveAddress(factory, { x: padHex(privateKeyToAddress(padHex("0xbee"))), y: zeroHash }),
+        externalAccount.id,
+        externalAccount.currency,
+      );
+    });
+
+    it("returns 500 when the offramp transfer fails", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      vi.spyOn(bridge, "createExternalAccount").mockResolvedValue(externalAccount);
+      vi.spyOn(bridge, "createOfframpTransfer").mockRejectedValue(new Error("boom"));
+
+      const response = await appClient["external-account"].$post(
+        { json: input },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(500);
     });
   });
 

--- a/server/test/api/ramp.test.ts
+++ b/server/test/api/ramp.test.ts
@@ -798,6 +798,8 @@ describe("ramp api", () => {
               address: deposit,
               fee: "0.0",
               estimatedProcessingTime: "300",
+              rail: "wire",
+              reference: "invoice 4021",
             },
           ]);
 
@@ -823,6 +825,8 @@ describe("ramp api", () => {
                 address: deposit,
                 fee: "0.0",
                 estimatedProcessingTime: "300",
+                rail: "wire",
+                reference: "invoice 4021",
               },
             ],
           });
@@ -1410,7 +1414,74 @@ describe("ramp api", () => {
         deriveAddress(factory, { x: padHex(privateKeyToAddress(padHex("0xbee"))), y: zeroHash }),
         externalAccount.id,
         externalAccount.currency,
+        undefined,
+        undefined,
       );
+    });
+
+    it("forwards the wire rail and reference to the offramp transfer", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      vi.spyOn(bridge, "createExternalAccount").mockResolvedValue(externalAccount);
+      const transferSpy = vi.spyOn(bridge, "createOfframpTransfer").mockResolvedValue(undefined as never);
+
+      const response = await appClient["external-account"].$post(
+        { json: { ...input, rail: "wire", reference: "invoice 4021" } },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(200);
+      expect(transferSpy).toHaveBeenCalledWith(
+        bridgeCustomer.id,
+        deriveAddress(factory, { x: padHex(privateKeyToAddress(padHex("0xbee"))), y: zeroHash }),
+        externalAccount.id,
+        externalAccount.currency,
+        "wire",
+        "invoice 4021",
+      );
+    });
+
+    it("omits the rail but forwards the reference for a non-usd account", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      vi.spyOn(bridge, "createExternalAccount").mockResolvedValue({ ...externalAccount, currency: "EUR" });
+      const transferSpy = vi.spyOn(bridge, "createOfframpTransfer").mockResolvedValue(undefined as never);
+
+      const response = await appClient["external-account"].$post(
+        {
+          json: {
+            currency: "EUR",
+            accountOwnerName: "Jane Doe",
+            accountOwnerType: "individual",
+            firstName: "Jane",
+            lastName: "Doe",
+            accountNumber: "DE89370400440532013000",
+            country: "DEU",
+            reference: "invoice 4021",
+          },
+        },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(200);
+      expect(transferSpy).toHaveBeenCalledWith(
+        bridgeCustomer.id,
+        deriveAddress(factory, { x: padHex(privateKeyToAddress(padHex("0xbee"))), y: zeroHash }),
+        externalAccount.id,
+        "EUR",
+        undefined,
+        "invoice 4021",
+      );
+    });
+
+    it("rejects a reference that exceeds the ach length", async () => {
+      const createSpy = vi.spyOn(bridge, "createExternalAccount");
+
+      const response = await appClient["external-account"].$post(
+        { json: { ...input, reference: "way too long reference" } },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      expect(createSpy).not.toHaveBeenCalled();
     });
 
     it("returns 500 when the offramp transfer fails", async () => {

--- a/server/test/utils/bridge.test.ts
+++ b/server/test/utils/bridge.test.ts
@@ -2863,50 +2863,17 @@ describe("bridge utils", () => {
       ]);
     });
 
-    it("creates a transfer when no matching static template exists", async () => {
+    it("throws OFFRAMP_TRANSFER_NOT_FOUND when no matching static template exists", async () => {
       const fetchSpy = vi
         .spyOn(globalThis, "fetch")
         .mockResolvedValueOnce(fetchResponse(externalAccountResponse("usd")))
-        .mockResolvedValueOnce(fetchResponse({ count: 0, data: [] }))
-        .mockResolvedValueOnce(
-          fetchResponse(staticTemplate({ externalAccountId: "ext-acc-1", currency: "usd", toAddress: deposit })),
-        );
+        .mockResolvedValueOnce(fetchResponse({ count: 0, data: [] }));
 
-      const result = await bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "USD");
-
-      expect(result).toStrictEqual([
-        { network: "OPTIMISM", displayName: "Optimism", address: deposit, fee: "0.0", estimatedProcessingTime: "300" },
-      ]);
-      expect(fetchSpy).toHaveBeenCalledTimes(3);
-      const transferCall = fetchSpy.mock.calls[2];
-      expect(transferCall?.[0]).toContain("/transfers");
-      expect(JSON.parse(transferCall?.[1]?.body as string)).toStrictEqual({
-        on_behalf_of: activeCustomer.id,
-        client_reference_id: account,
-        source: { currency: "usdc", payment_rail: "optimism" },
-        destination: { currency: "usd", payment_rail: "ach", external_account_id: "ext-acc-1" },
-        features: { flexible_amount: true, static_template: true, allow_any_from_address: true },
-      });
-    });
-
-    it("creates a transfer with the eur payment rail for an eur external account", async () => {
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValueOnce(fetchResponse(externalAccountResponse("eur")))
-        .mockResolvedValueOnce(fetchResponse({ count: 0, data: [] }))
-        .mockResolvedValueOnce(
-          fetchResponse(staticTemplate({ externalAccountId: "ext-acc-1", currency: "eur", toAddress: deposit })),
-        );
-
-      await bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "EUR");
-
-      expect(JSON.parse(fetchSpy.mock.calls[2]?.[1]?.body as string)).toStrictEqual({
-        on_behalf_of: activeCustomer.id,
-        client_reference_id: account,
-        source: { currency: "usdc", payment_rail: "optimism" },
-        destination: { currency: "eur", payment_rail: "sepa", external_account_id: "ext-acc-1" },
-        features: { flexible_amount: true, static_template: true, allow_any_from_address: true },
-      });
+      await expect(bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "USD")).rejects.toThrow(
+        bridge.ErrorCodes.OFFRAMP_TRANSFER_NOT_FOUND,
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(fetchSpy.mock.calls.every((call) => call[1]?.method !== "POST")).toBe(true);
     });
 
     it("ignores static templates with mismatched source payment rail", async () => {
@@ -2925,14 +2892,12 @@ describe("bridge utils", () => {
               }),
             ],
           }),
-        )
-        .mockResolvedValueOnce(
-          fetchResponse(staticTemplate({ externalAccountId: "ext-acc-1", currency: "usd", toAddress: deposit })),
         );
 
-      await bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "USD");
-
-      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      await expect(bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "USD")).rejects.toThrow(
+        bridge.ErrorCodes.OFFRAMP_TRANSFER_NOT_FOUND,
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
 
     it("ignores static templates for a different external account", async () => {
@@ -2944,14 +2909,12 @@ describe("bridge utils", () => {
             count: 1,
             data: [staticTemplate({ externalAccountId: "ext-acc-other", currency: "usd", toAddress: deposit })],
           }),
-        )
-        .mockResolvedValueOnce(
-          fetchResponse(staticTemplate({ externalAccountId: "ext-acc-1", currency: "usd", toAddress: deposit })),
         );
 
-      await bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "USD");
-
-      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      await expect(bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "USD")).rejects.toThrow(
+        bridge.ErrorCodes.OFFRAMP_TRANSFER_NOT_FOUND,
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
 
     it("throws on an invalid to_address", async () => {
@@ -3017,7 +2980,7 @@ describe("bridge utils", () => {
       expect(fetchSpy.mock.calls.every((call) => call[1]?.method !== "POST")).toBe(true);
     });
 
-    it("ignores canceled templates and creates a new transfer", async () => {
+    it("ignores canceled templates", async () => {
       const fetchSpy = vi
         .spyOn(globalThis, "fetch")
         .mockResolvedValueOnce(fetchResponse(externalAccountResponse("usd")))
@@ -3031,18 +2994,74 @@ describe("bridge utils", () => {
               },
             ],
           }),
-        )
+        );
+
+      await expect(bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "USD")).rejects.toThrow(
+        bridge.ErrorCodes.OFFRAMP_TRANSFER_NOT_FOUND,
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("createOfframpTransfer", () => {
+    const account = parse(Address, padHex("0x1", { size: 20 }));
+    const deposit = parse(Address, padHex("0xde9", { size: 20 }));
+
+    it("throws NOT_SUPPORTED_CHAIN_ID for unsupported chain", async () => {
+      chainMock.id = 1;
+
+      await expect(bridge.createOfframpTransfer(activeCustomer.id, account, "ext-acc-1", "USD")).rejects.toThrow(
+        bridge.ErrorCodes.NOT_SUPPORTED_CHAIN_ID,
+      );
+      expect(captureException).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "bridge not supported chain id" }),
+        expect.objectContaining({ level: "error" }),
+      );
+    });
+
+    it("throws NOT_AVAILABLE_CURRENCY when currency has no payment rail mapping", async () => {
+      await expect(bridge.createOfframpTransfer(activeCustomer.id, account, "ext-acc-usdc", "USDC")).rejects.toThrow(
+        bridge.ErrorCodes.NOT_AVAILABLE_CURRENCY,
+      );
+    });
+
+    it("creates a transfer with the ach payment rail for a usd external account", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
         .mockResolvedValueOnce(
           fetchResponse(staticTemplate({ externalAccountId: "ext-acc-1", currency: "usd", toAddress: deposit })),
         );
 
-      const result = await bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "USD");
+      const result = await bridge.createOfframpTransfer(activeCustomer.id, account, "ext-acc-1", "USD");
 
-      expect(result).toStrictEqual([
-        { network: "OPTIMISM", displayName: "Optimism", address: deposit, fee: "0.0", estimatedProcessingTime: "300" },
-      ]);
-      expect(fetchSpy).toHaveBeenCalledTimes(3);
-      expect(fetchSpy.mock.calls[2]?.[0] as string).toContain("/transfers");
+      expect(result.source_deposit_instructions.to_address).toBe(deposit);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy.mock.calls[0]?.[0]).toContain("/transfers");
+      expect(JSON.parse(fetchSpy.mock.calls[0]?.[1]?.body as string)).toStrictEqual({
+        on_behalf_of: activeCustomer.id,
+        client_reference_id: account,
+        source: { currency: "usdc", payment_rail: "optimism" },
+        destination: { currency: "usd", payment_rail: "ach", external_account_id: "ext-acc-1" },
+        features: { flexible_amount: true, static_template: true, allow_any_from_address: true },
+      });
+    });
+
+    it("creates a transfer with the sepa payment rail for an eur external account", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(
+          fetchResponse(staticTemplate({ externalAccountId: "ext-acc-1", currency: "eur", toAddress: deposit })),
+        );
+
+      await bridge.createOfframpTransfer(activeCustomer.id, account, "ext-acc-1", "EUR");
+
+      expect(JSON.parse(fetchSpy.mock.calls[0]?.[1]?.body as string)).toStrictEqual({
+        on_behalf_of: activeCustomer.id,
+        client_reference_id: account,
+        source: { currency: "usdc", payment_rail: "optimism" },
+        destination: { currency: "eur", payment_rail: "sepa", external_account_id: "ext-acc-1" },
+        features: { flexible_amount: true, static_template: true, allow_any_from_address: true },
+      });
     });
   });
 

--- a/server/test/utils/bridge.test.ts
+++ b/server/test/utils/bridge.test.ts
@@ -2840,9 +2840,106 @@ describe("bridge utils", () => {
       const result = await bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "USD");
 
       expect(result).toStrictEqual([
-        { network: "OPTIMISM", displayName: "Optimism", address: deposit, fee: "0.0", estimatedProcessingTime: "300" },
+        {
+          network: "OPTIMISM",
+          displayName: "Optimism",
+          address: deposit,
+          fee: "0.0",
+          estimatedProcessingTime: "300",
+          rail: "ach",
+          reference: undefined,
+        },
       ]);
       expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+      {
+        name: "ach_reference from a usd account",
+        accountCurrency: "usd" as const,
+        currency: "USD" as const,
+        template: staticTemplate({
+          externalAccountId: "ext-acc-1",
+          currency: "usd",
+          toAddress: deposit,
+          reference: "rent 04",
+        }),
+        rail: "ach" as const,
+        reference: "rent 04",
+      },
+      {
+        name: "wire_message from a usd wire account",
+        accountCurrency: "usd" as const,
+        currency: "USD" as const,
+        template: {
+          ...staticTemplate({ externalAccountId: "ext-acc-1", currency: "usd", toAddress: deposit }),
+          destination: {
+            payment_rail: "wire",
+            currency: "usd",
+            external_account_id: "ext-acc-1",
+            wire_message: "invoice 4021",
+          },
+        },
+        rail: "wire" as const,
+        reference: "invoice 4021",
+      },
+      {
+        name: "sepa_reference from a eur account",
+        accountCurrency: "eur" as const,
+        currency: "EUR" as const,
+        template: staticTemplate({
+          externalAccountId: "ext-acc-1",
+          currency: "eur",
+          toAddress: deposit,
+          reference: "invoice 4021",
+        }),
+        rail: undefined,
+        reference: "invoice 4021",
+      },
+      {
+        name: "spei_reference from a mxn account",
+        accountCurrency: "mxn" as const,
+        currency: "MXN" as const,
+        template: staticTemplate({
+          externalAccountId: "ext-acc-1",
+          currency: "mxn",
+          toAddress: deposit,
+          reference: "order 04",
+        }),
+        rail: undefined,
+        reference: "order 04",
+      },
+      {
+        name: "generic reference from a brl account",
+        accountCurrency: "brl" as const,
+        currency: "BRL" as const,
+        template: staticTemplate({
+          externalAccountId: "ext-acc-1",
+          currency: "brl",
+          toAddress: deposit,
+          reference: "order 05",
+        }),
+        rail: undefined,
+        reference: "order 05",
+      },
+    ])("returns the stored $name", async ({ accountCurrency, currency, template, rail, reference }) => {
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(fetchResponse(externalAccountResponse(accountCurrency)))
+        .mockResolvedValueOnce(fetchResponse({ count: 1, data: [template] }));
+
+      const result = await bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, currency);
+
+      expect(result).toStrictEqual([
+        {
+          network: "OPTIMISM",
+          displayName: "Optimism",
+          address: deposit,
+          fee: "0.0",
+          estimatedProcessingTime: "300",
+          rail,
+          reference,
+        },
+      ]);
     });
 
     it("matches static template on optimism for optimism sepolia chain", async () => {
@@ -2859,7 +2956,15 @@ describe("bridge utils", () => {
       const result = await bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "EUR");
 
       expect(result).toStrictEqual([
-        { network: "OPTIMISM", displayName: "Optimism", address: deposit, fee: "0.0", estimatedProcessingTime: "300" },
+        {
+          network: "OPTIMISM",
+          displayName: "Optimism",
+          address: deposit,
+          fee: "0.0",
+          estimatedProcessingTime: "300",
+          rail: undefined,
+          reference: undefined,
+        },
       ]);
     });
 
@@ -2974,7 +3079,15 @@ describe("bridge utils", () => {
       const result = await bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "USD");
 
       expect(result).toStrictEqual([
-        { network: "OPTIMISM", displayName: "Optimism", address: deposit, fee: "0.0", estimatedProcessingTime: "300" },
+        {
+          network: "OPTIMISM",
+          displayName: "Optimism",
+          address: deposit,
+          fee: "0.0",
+          estimatedProcessingTime: "300",
+          rail: "ach",
+          reference: undefined,
+        },
       ]);
       expect(fetchSpy).toHaveBeenCalledTimes(2);
       expect(fetchSpy.mock.calls.every((call) => call[1]?.method !== "POST")).toBe(true);
@@ -3020,19 +3133,117 @@ describe("bridge utils", () => {
     });
 
     it("throws NOT_AVAILABLE_CURRENCY when currency has no payment rail mapping", async () => {
-      await expect(bridge.createOfframpTransfer(activeCustomer.id, account, "ext-acc-usdc", "USDC")).rejects.toThrow(
-        bridge.ErrorCodes.NOT_AVAILABLE_CURRENCY,
-      );
+      await expect(
+        bridge.createOfframpTransfer(activeCustomer.id, account, "ext-acc-usdc", "USDC" as never),
+      ).rejects.toThrow(bridge.ErrorCodes.NOT_AVAILABLE_CURRENCY);
     });
 
-    it("creates a transfer with the ach payment rail for a usd external account", async () => {
+    it.each([
+      {
+        name: "uses the ach rail for a usd account",
+        currency: "USD",
+        rail: undefined,
+        reference: undefined,
+        destination: { currency: "usd", payment_rail: "ach", external_account_id: "ext-acc-1" },
+      },
+      {
+        name: "uses the sepa rail for a eur account",
+        currency: "EUR",
+        rail: undefined,
+        reference: undefined,
+        destination: { currency: "eur", payment_rail: "sepa", external_account_id: "ext-acc-1" },
+      },
+      {
+        name: "sends the ach reference for a usd account",
+        currency: "USD",
+        rail: "ach",
+        reference: "rent 04",
+        destination: {
+          currency: "usd",
+          payment_rail: "ach",
+          external_account_id: "ext-acc-1",
+          ach_reference: "rent 04",
+        },
+      },
+      {
+        name: "sends the wire message for a usd wire account",
+        currency: "USD",
+        rail: "wire",
+        reference: "invoice 4021",
+        destination: {
+          currency: "usd",
+          payment_rail: "wire",
+          external_account_id: "ext-acc-1",
+          wire_message: "invoice 4021",
+        },
+      },
+      {
+        name: "sends the spei reference for a mxn account",
+        currency: "MXN",
+        rail: undefined,
+        reference: "order 04",
+        destination: {
+          currency: "mxn",
+          payment_rail: "spei",
+          external_account_id: "ext-acc-1",
+          spei_reference: "order 04",
+        },
+      },
+      {
+        name: "sends the generic reference for a brl pix account",
+        currency: "BRL",
+        rail: undefined,
+        reference: "order 05",
+        destination: { currency: "brl", payment_rail: "pix", external_account_id: "ext-acc-1", reference: "order 05" },
+      },
+      {
+        name: "sends the sepa reference for a eur account",
+        currency: "EUR",
+        rail: undefined,
+        reference: "invoice 4021",
+        destination: {
+          currency: "eur",
+          payment_rail: "sepa",
+          external_account_id: "ext-acc-1",
+          sepa_reference: "invoice 4021",
+        },
+      },
+      {
+        name: "sends the generic reference for a gbp faster payments account",
+        currency: "GBP",
+        rail: undefined,
+        reference: "fp memo 4021",
+        destination: {
+          currency: "gbp",
+          payment_rail: "faster_payments",
+          external_account_id: "ext-acc-1",
+          reference: "fp memo 4021",
+        },
+      },
+      {
+        name: "omits the reference when none is provided",
+        currency: "GBP",
+        rail: undefined,
+        reference: undefined,
+        destination: { currency: "gbp", payment_rail: "faster_payments", external_account_id: "ext-acc-1" },
+      },
+    ] as const)("$name", async ({ currency, rail, reference, destination }) => {
       const fetchSpy = vi
         .spyOn(globalThis, "fetch")
         .mockResolvedValueOnce(
-          fetchResponse(staticTemplate({ externalAccountId: "ext-acc-1", currency: "usd", toAddress: deposit })),
+          fetchResponse(
+            staticTemplate({ externalAccountId: "ext-acc-1", currency: destination.currency, toAddress: deposit }),
+          ),
         );
 
-      const result = await bridge.createOfframpTransfer(activeCustomer.id, account, "ext-acc-1", "USD");
+      const result = await bridge.createOfframpTransfer(
+        activeCustomer.id,
+        account,
+        "ext-acc-1",
+        currency,
+        rail,
+        reference,
+      );
 
       expect(result.source_deposit_instructions.to_address).toBe(deposit);
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -3041,25 +3252,7 @@ describe("bridge utils", () => {
         on_behalf_of: activeCustomer.id,
         client_reference_id: account,
         source: { currency: "usdc", payment_rail: "optimism" },
-        destination: { currency: "usd", payment_rail: "ach", external_account_id: "ext-acc-1" },
-        features: { flexible_amount: true, static_template: true, allow_any_from_address: true },
-      });
-    });
-
-    it("creates a transfer with the sepa payment rail for an eur external account", async () => {
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValueOnce(
-          fetchResponse(staticTemplate({ externalAccountId: "ext-acc-1", currency: "eur", toAddress: deposit })),
-        );
-
-      await bridge.createOfframpTransfer(activeCustomer.id, account, "ext-acc-1", "EUR");
-
-      expect(JSON.parse(fetchSpy.mock.calls[0]?.[1]?.body as string)).toStrictEqual({
-        on_behalf_of: activeCustomer.id,
-        client_reference_id: account,
-        source: { currency: "usdc", payment_rail: "optimism" },
-        destination: { currency: "eur", payment_rail: "sepa", external_account_id: "ext-acc-1" },
+        destination,
         features: { flexible_amount: true, static_template: true, allow_any_from_address: true },
       });
     });
@@ -3280,6 +3473,149 @@ describe("bridge utils", () => {
         lastName: "Doe",
         accountNumber: "DE89370400440532013000",
         country: "DEU",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts legacy USD input without rail or reference", () => {
+      const result = safeParse(bridge.ExternalAccountInput, {
+        currency: "USD",
+        accountOwnerName: "John Doe",
+        accountNumber: "1210002481111",
+        routingNumber: "121000248",
+        address: usdAddress,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts USD wire input with a reference", () => {
+      const result = safeParse(bridge.ExternalAccountInput, {
+        currency: "USD",
+        rail: "wire",
+        accountOwnerName: "John Doe",
+        accountNumber: "1210002481111",
+        routingNumber: "121000248",
+        address: usdAddress,
+        reference: "invoice 4021",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a wire message with a line over 35 characters", () => {
+      const result = safeParse(bridge.ExternalAccountInput, {
+        currency: "USD",
+        rail: "wire",
+        accountOwnerName: "John Doe",
+        accountNumber: "1210002481111",
+        routingNumber: "121000248",
+        address: usdAddress,
+        reference: "this single wire line is way too long to pass",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a wire message spread over four lines", () => {
+      const result = safeParse(bridge.ExternalAccountInput, {
+        currency: "USD",
+        rail: "wire",
+        accountOwnerName: "John Doe",
+        accountNumber: "1210002481111",
+        routingNumber: "121000248",
+        address: usdAddress,
+        reference: "line one\nline two\nline three\nline four",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a wire message with more than four lines", () => {
+      const result = safeParse(bridge.ExternalAccountInput, {
+        currency: "USD",
+        rail: "wire",
+        accountOwnerName: "John Doe",
+        accountNumber: "1210002481111",
+        routingNumber: "121000248",
+        address: usdAddress,
+        reference: "line one\nline two\nline three\nline four\nline five",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts USD ach input with a short reference", () => {
+      const result = safeParse(bridge.ExternalAccountInput, {
+        currency: "USD",
+        accountOwnerName: "John Doe",
+        accountNumber: "1210002481111",
+        routingNumber: "121000248",
+        address: usdAddress,
+        reference: "rent 04",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a USD ach reference longer than 10 characters", () => {
+      const result = safeParse(bridge.ExternalAccountInput, {
+        currency: "USD",
+        accountOwnerName: "John Doe",
+        accountNumber: "1210002481111",
+        routingNumber: "121000248",
+        address: usdAddress,
+        reference: "way too long reference",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a non-USD reference", () => {
+      const result = safeParse(bridge.ExternalAccountInput, {
+        currency: "GBP",
+        accountOwnerName: "Jane Doe",
+        accountNumber: "12345678",
+        sortCode: "123456",
+        reference: "fp memo 4021",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a faster payments reference longer than 18 characters", () => {
+      const result = safeParse(bridge.ExternalAccountInput, {
+        currency: "GBP",
+        accountOwnerName: "Jane Doe",
+        accountNumber: "12345678",
+        sortCode: "123456",
+        reference: "this reference is definitely too long",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a sepa reference shorter than 6 characters", () => {
+      const result = safeParse(bridge.ExternalAccountInput, {
+        currency: "EUR",
+        accountOwnerName: "Jane Doe",
+        accountOwnerType: "individual",
+        firstName: "Jane",
+        lastName: "Doe",
+        accountNumber: "DE89370400440532013000",
+        country: "DEU",
+        reference: "abc",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a pix reference longer than 18 characters", () => {
+      const result = safeParse(bridge.ExternalAccountInput, {
+        currency: "BRL",
+        accountOwnerName: "John Doe",
+        account: { pixKey: "john@example.com" },
+        reference: "payment for july rent invoice 4021",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts a spei reference longer than 18 characters", () => {
+      const result = safeParse(bridge.ExternalAccountInput, {
+        currency: "MXN",
+        accountOwnerName: "John Doe",
+        clabe: "012345678901234567",
+        reference: "monthly rent payment 07",
       });
       expect(result.success).toBe(true);
     });
@@ -4359,19 +4695,33 @@ function staticTemplate({
   currency,
   toAddress,
   sourcePaymentRail = "optimism",
+  reference,
 }: {
   currency: "brl" | "eur" | "gbp" | "mxn" | "usd";
   externalAccountId: string;
+  reference?: string;
   sourcePaymentRail?: "base" | "optimism";
   toAddress: null | string;
 }) {
   const destinationPaymentRail = { brl: "pix", eur: "sepa", gbp: "faster_payments", mxn: "spei", usd: "ach" }[currency];
+  const referenceField = {
+    brl: "reference",
+    eur: "sepa_reference",
+    gbp: "reference",
+    mxn: "spei_reference",
+    usd: "ach_reference",
+  }[currency];
   return {
     id: `tr-${externalAccountId}-${currency}`,
     state: "awaiting_funds" as const,
     on_behalf_of: "cust-123",
     source: { payment_rail: sourcePaymentRail, currency: "usdc" },
-    destination: { payment_rail: destinationPaymentRail, currency, external_account_id: externalAccountId },
+    destination: {
+      payment_rail: destinationPaymentRail,
+      currency,
+      external_account_id: externalAccountId,
+      ...(reference && { [referenceField]: reference }),
+    },
     source_deposit_instructions: { payment_rail: sourcePaymentRail, currency: "usdc", to_address: toAddress },
   };
 }

--- a/server/utils/ramps/bridge.ts
+++ b/server/utils/ramps/bridge.ts
@@ -938,6 +938,32 @@ export async function getCryptoDepositDetails(
   );
 }
 
+export async function createOfframpTransfer(
+  customerId: string,
+  account: string,
+  externalAccountId: string,
+  currency: (typeof SupportedCurrency)[number],
+) {
+  const supportedChain = Supported[chain.id];
+  if (!supportedChain) {
+    captureException(new Error("bridge not supported chain id"), { contexts: { chain }, level: "error" });
+    throw new Error(ErrorCodes.NOT_SUPPORTED_CHAIN_ID);
+  }
+  const paymentRail = PaymentRailByBridgeCurrency[CurrencyToBridge[currency]];
+  if (!paymentRail) throw new Error(ErrorCodes.NOT_AVAILABLE_CURRENCY);
+  return await createTransfer({
+    on_behalf_of: customerId,
+    client_reference_id: account,
+    source: { currency: "usdc", payment_rail: supportedChain },
+    destination: {
+      currency: CurrencyToBridge[currency],
+      payment_rail: paymentRail,
+      external_account_id: externalAccountId,
+    },
+    features: { flexible_amount: true, static_template: true, allow_any_from_address: true },
+  });
+}
+
 export async function getOfframpDepositDetails(
   externalAccountId: string,
   account: string,
@@ -959,24 +985,14 @@ export async function getOfframpDepositDetails(
   const paymentRail = PaymentRailByBridgeCurrency[externalAccount.currency];
   if (!paymentRail) throw new Error(ErrorCodes.NOT_AVAILABLE_CURRENCY);
   const templates = await getStaticTemplates(customer.id);
-  let transfer = templates.find(
+  const transfer = templates.find(
     ({ destination, source, state }) =>
       destination.external_account_id === externalAccountId &&
       source.payment_rail === supportedChain &&
       source.currency === "usdc" &&
       state !== "canceled",
   );
-  transfer ??= await createTransfer({
-    on_behalf_of: customer.id,
-    client_reference_id: account,
-    source: { currency: "usdc", payment_rail: supportedChain },
-    destination: {
-      currency: externalAccount.currency,
-      payment_rail: paymentRail,
-      external_account_id: externalAccountId,
-    },
-    features: { flexible_amount: true, static_template: true, allow_any_from_address: true },
-  });
+  if (!transfer) throw new Error(ErrorCodes.OFFRAMP_TRANSFER_NOT_FOUND);
 
   return [
     {
@@ -2208,20 +2224,21 @@ export const ErrorCodes = {
   INVALID_ADDRESS: "invalid address",
   INVALID_BANK_NAME: "invalid bank name",
   INVALID_DEPOSIT_ADDRESS: "invalid deposit address",
-  NOT_ACTIVE_CUSTOMER: "not active customer",
+  MISSING_STELLAR_MEMO: "missing stellar memo",
+  NO_COUNTRY_ALPHA3: "no country alpha3",
+  NO_DOCUMENT: "no document",
+  NO_DOCUMENT_FILE: "no document file",
   NO_ENDORSEMENT: "no endorsement",
+  NO_PERSONA_ACCOUNT: "no persona account",
+  NO_SOCIAL_SECURITY_NUMBER: "no social security number",
+  NOT_ACTIVE_CUSTOMER: "not active customer",
   NOT_AVAILABLE_CRYPTO_PAYMENT_RAIL: "not available crypto payment rail",
   NOT_AVAILABLE_CURRENCY: "not available currency",
-  MISSING_STELLAR_MEMO: "missing stellar memo",
   NOT_AVAILABLE_EVM_NETWORK: "not available evm network",
   NOT_ENABLED: "not enabled",
   NOT_FOUND_IDENTIFICATION_CLASS: "not found identification class",
   NOT_SUPPORTED_CHAIN_ID: "not supported chain id",
-  NO_COUNTRY_ALPHA3: "no country alpha3",
-  NO_DOCUMENT: "no document",
-  NO_DOCUMENT_FILE: "no document file",
-  NO_PERSONA_ACCOUNT: "no persona account",
-  NO_SOCIAL_SECURITY_NUMBER: "no social security number",
+  OFFRAMP_TRANSFER_NOT_FOUND: "offramp transfer not found",
   POSTAL_CODE_REQUIRED: "postal code required",
   TRANSFER_IN_USE: "transfer in use",
 };

--- a/server/utils/ramps/bridge.ts
+++ b/server/utils/ramps/bridge.ts
@@ -942,14 +942,16 @@ export async function createOfframpTransfer(
   customerId: string,
   account: string,
   externalAccountId: string,
-  currency: (typeof SupportedCurrency)[number],
+  currency: (typeof FiatCurrency)[number],
+  rail?: "ach" | "wire",
+  reference?: string,
 ) {
   const supportedChain = Supported[chain.id];
   if (!supportedChain) {
     captureException(new Error("bridge not supported chain id"), { contexts: { chain }, level: "error" });
     throw new Error(ErrorCodes.NOT_SUPPORTED_CHAIN_ID);
   }
-  const paymentRail = PaymentRailByBridgeCurrency[CurrencyToBridge[currency]];
+  const paymentRail = rail ?? PaymentRailByBridgeCurrency[CurrencyToBridge[currency]];
   if (!paymentRail) throw new Error(ErrorCodes.NOT_AVAILABLE_CURRENCY);
   return await createTransfer({
     on_behalf_of: customerId,
@@ -959,6 +961,11 @@ export async function createOfframpTransfer(
       currency: CurrencyToBridge[currency],
       payment_rail: paymentRail,
       external_account_id: externalAccountId,
+      ach_reference: paymentRail === "ach" ? reference : undefined,
+      wire_message: paymentRail === "wire" ? reference : undefined,
+      sepa_reference: paymentRail === "sepa" ? reference : undefined,
+      spei_reference: paymentRail === "spei" ? reference : undefined,
+      reference: paymentRail === "pix" || paymentRail === "faster_payments" ? reference : undefined,
     },
     features: { flexible_amount: true, static_template: true, allow_any_from_address: true },
   });
@@ -1001,6 +1008,17 @@ export async function getOfframpDepositDetails(
       address: parse(Address, transfer.source_deposit_instructions.to_address),
       fee: "0.0",
       estimatedProcessingTime: "300",
+      rail:
+        transfer.destination.payment_rail === "ach" || transfer.destination.payment_rail === "wire"
+          ? transfer.destination.payment_rail
+          : undefined,
+      reference:
+        transfer.destination.ach_reference ??
+        transfer.destination.wire_message ??
+        transfer.destination.sepa_reference ??
+        transfer.destination.spei_reference ??
+        transfer.destination.reference ??
+        undefined,
     },
   ];
 }
@@ -1582,6 +1600,13 @@ const BankName = pipe(string(), minLength(1), maxLength(256));
 const RoutingNumber = pipe(string(), regex(/^\d{9}$/, "9 digits"));
 const DocumentNumber = pipe(string(), regex(/^\d+$/, "digits only"));
 const CountryCode = pipe(string(), length(3, "3-letter iso 3166-1 code"));
+const SepaReference = pipe(
+  string(),
+  minLength(6, "6-140 characters"),
+  maxLength(140, "6-140 characters"),
+  regex(/^[\dA-Z &./-]+$/i, "letters, digits, spaces and & - . /"),
+);
+const FasterPaymentsReference = pipe(string(), minLength(1), maxLength(18, "1-18 characters"));
 
 const AddressInput = object({
   streetLine1: pipe(string(), minLength(4), maxLength(35)),
@@ -1592,18 +1617,45 @@ const AddressInput = object({
   country: CountryCode,
 });
 
+const UsdAccount = object({
+  currency: literal("USD"),
+  accountOwnerName: AccountOwnerName,
+  accountNumber: pipe(string(), minLength(1)),
+  routingNumber: RoutingNumber,
+  checkingOrSavings: optional(picklist(["checking", "savings"])),
+  bankName: optional(BankName),
+  address: object({
+    ...AddressInput.entries,
+    state: pipe(string(), minLength(1), maxLength(3, "1-3 character iso 3166-2 code")),
+  }),
+});
+
 export const ExternalAccountInput = variant("currency", [
   object({
-    currency: literal("USD"),
-    accountOwnerName: AccountOwnerName,
-    accountNumber: pipe(string(), minLength(1)),
-    routingNumber: RoutingNumber,
-    checkingOrSavings: optional(picklist(["checking", "savings"])),
-    bankName: optional(BankName),
-    address: object({
-      ...AddressInput.entries,
-      state: pipe(string(), minLength(1), maxLength(3, "1-3 character iso 3166-2 code")),
-    }),
+    ...UsdAccount.entries,
+    rail: literal("wire"),
+    reference: optional(
+      pipe(
+        string(),
+        minLength(1),
+        check(
+          (value) => value.split("\n").every((line, index) => index < 4 && line.length <= 35),
+          "up to 4 lines of 35 characters",
+        ),
+      ),
+    ),
+  }),
+  object({
+    ...UsdAccount.entries,
+    rail: optional(literal("ach")),
+    reference: optional(
+      pipe(
+        string(),
+        minLength(1),
+        maxLength(10, "1-10 characters"),
+        regex(/^[\dA-Z ]+$/i, "letters, digits and spaces"),
+      ),
+    ),
   }),
   object({
     currency: literal("EUR"),
@@ -1616,6 +1668,7 @@ export const ExternalAccountInput = variant("currency", [
     bic: optional(pipe(string(), minLength(1))),
     country: CountryCode,
     bankName: optional(BankName),
+    reference: optional(SepaReference),
   }),
   object({
     currency: literal("EUR"),
@@ -1627,6 +1680,7 @@ export const ExternalAccountInput = variant("currency", [
     bic: optional(pipe(string(), minLength(1))),
     country: CountryCode,
     bankName: optional(BankName),
+    reference: optional(SepaReference),
   }),
   object({
     currency: literal("MXN"),
@@ -1634,6 +1688,14 @@ export const ExternalAccountInput = variant("currency", [
     accountOwnerName: AccountOwnerName,
     clabe: pipe(string(), regex(/^\d{18}$/, "18 digits")),
     bankName: optional(BankName),
+    reference: optional(
+      pipe(
+        string(),
+        minLength(1),
+        maxLength(40, "1-40 characters"),
+        regex(/^[\dA-Z ]+$/i, "letters, digits and spaces"),
+      ),
+    ),
   }),
   object({
     currency: literal("BRL"),
@@ -1644,6 +1706,7 @@ export const ExternalAccountInput = variant("currency", [
       object({ brCode: pipe(string(), minLength(1)), documentNumber: optional(DocumentNumber) }),
     ]),
     bankName: optional(BankName),
+    reference: optional(pipe(string(), minLength(1), maxLength(100, "1-100 characters"))),
   }),
   object({
     currency: literal("GBP"),
@@ -1655,6 +1718,7 @@ export const ExternalAccountInput = variant("currency", [
     accountNumber: pipe(string(), regex(/^\d{8}$/, "8 digits")),
     sortCode: pipe(string(), regex(/^\d{6}$/, "6 digits, no hyphens")),
     bankName: optional(BankName),
+    reference: optional(FasterPaymentsReference),
   }),
   object({
     currency: literal("GBP"),
@@ -1665,6 +1729,7 @@ export const ExternalAccountInput = variant("currency", [
     accountNumber: pipe(string(), regex(/^\d{8}$/, "8 digits")),
     sortCode: pipe(string(), regex(/^\d{6}$/, "6 digits, no hyphens")),
     bankName: optional(BankName),
+    reference: optional(FasterPaymentsReference),
   }),
   object({
     currency: literal("GBP"),
@@ -1673,6 +1738,7 @@ export const ExternalAccountInput = variant("currency", [
     accountNumber: pipe(string(), regex(/^\d{8}$/, "8 digits")),
     sortCode: pipe(string(), regex(/^\d{6}$/, "6 digits, no hyphens")),
     bankName: optional(BankName),
+    reference: optional(FasterPaymentsReference),
   }),
 ]);
 
@@ -1988,6 +2054,7 @@ const CreateTransfer = object({
     swift_reference: optional(string()),
     spei_reference: optional(string()),
     ach_reference: optional(string()),
+    reference: optional(string()),
     blockchain_memo: optional(string()),
     swift_charges: optional(picklist(["ben", "our", "sha"])),
   }),
@@ -2008,11 +2075,16 @@ const Transfer = object({
     from_address: nullish(string()),
   }),
   destination: object({
+    ach_reference: nullish(string()),
     blockchain_memo: nullish(string()),
     currency: picklist(TransferCurrency),
     external_account_id: nullish(string()),
     payment_rail: picklist(TransferPaymentRail),
+    reference: nullish(string()),
+    sepa_reference: nullish(string()),
+    spei_reference: nullish(string()),
     to_address: nullish(string()),
+    wire_message: nullish(string()),
   }),
   source_deposit_instructions: object({
     payment_rail: picklist(TransferPaymentRail),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Off-ramp transfers are now created automatically when an external account is added, and the response is returned only after the transfer succeeds.
  * Transfer references are supported across ACH, wire, SEPA, SPEI, PIX, and Faster Payments.
  * Deposit details can include an optional reference, including Optimism deposits.
* **Bug Fixes**
  * Improved handling of missing off-ramp transfers with clearer errors.
  * Strengthened validation for rail-specific reference formats and lengths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->