### PR TITLE
✨ server: add auth method to sardine

### DIFF
--- a/.changeset/quiet-otters-tag.md
+++ b/.changeset/quiet-otters-tag.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+✨ add auth method to sardine

--- a/server/test/api/auth.test.ts
+++ b/server/test/api/auth.test.ts
@@ -437,7 +437,13 @@ describe("authentication", () => {
     expect(customer).toHaveBeenCalledWith(
       expect.objectContaining({
         flow: { name: "signup", type: "signup" },
-        customer: { id, tags: [{ name: "source", value: "12345", type: "string" }] },
+        customer: {
+          id,
+          tags: [
+            { name: "source", value: "12345", type: "string" },
+            { name: "auth_method", value: "siwe", type: "string" },
+          ],
+        },
       }),
     );
 
@@ -463,7 +469,13 @@ describe("authentication", () => {
     expect(customer).toHaveBeenCalledWith(
       expect.objectContaining({
         flow: { name: "signup", type: "signup" },
-        customer: { id, tags: [{ name: "source", value: "EXA", type: "string" }] },
+        customer: {
+          id,
+          tags: [
+            { name: "source", value: "EXA", type: "string" },
+            { name: "auth_method", value: "siwe", type: "string" },
+          ],
+        },
       }),
     );
 
@@ -704,7 +716,13 @@ describe("registration", () => {
     expect(customer).toHaveBeenCalledWith(
       expect.objectContaining({
         flow: { name: "signup", type: "signup" },
-        customer: { id, tags: [{ name: "source", value: "EXA", type: "string" }] },
+        customer: {
+          id,
+          tags: [
+            { name: "source", value: "EXA", type: "string" },
+            { name: "auth_method", value: "siwe", type: "string" },
+          ],
+        },
       }),
     );
 
@@ -775,7 +793,13 @@ describe("registration", () => {
     expect(customer).toHaveBeenCalledWith(
       expect.objectContaining({
         flow: { name: "signup", type: "signup" },
-        customer: { id: "dGVzdC1jcmVkLWlk2", tags: [{ name: "source", value: "12345", type: "string" }] },
+        customer: {
+          id: "dGVzdC1jcmVkLWlk2",
+          tags: [
+            { name: "source", value: "12345", type: "string" },
+            { name: "auth_method", value: "webauthn", type: "string" },
+          ],
+        },
       }),
     );
 
@@ -850,7 +874,13 @@ describe("registration", () => {
     expect(customer).toHaveBeenCalledWith(
       expect.objectContaining({
         flow: { name: "signup", type: "signup" },
-        customer: { id: "YW5vdGhlci1jcmVkLWlk2", tags: [{ name: "source", value: "EXA", type: "string" }] },
+        customer: {
+          id: "YW5vdGhlci1jcmVkLWlk2",
+          tags: [
+            { name: "source", value: "EXA", type: "string" },
+            { name: "auth_method", value: "webauthn", type: "string" },
+          ],
+        },
       }),
     );
     const credential = await database.query.credentials.findFirst({

--- a/server/utils/createCredential.ts
+++ b/server/utils/createCredential.ts
@@ -60,7 +60,10 @@ export default async function createCredential<C extends string>(
       flow: { name: "signup", type: "signup" },
       customer: {
         id: credentialId,
-        tags: [{ name: "source", value: options?.source ?? "EXA", type: "string" }],
+        tags: [
+          { name: "source", value: options?.source ?? "EXA", type: "string" },
+          { name: "auth_method", value: isAddress(credentialId) ? "siwe" : "webauthn", type: "string" },
+        ],
       },
     }).catch((error: unknown) => captureException(error, { level: "error" })),
   ]);


### PR DESCRIPTION
## Summary

- send `siwe` or `webauthn` to Sardine through the existing customer tag shape
- preserve the existing source tag and legacy WebAuthn fallback
- keep client-IP forwarding from issue #1171 out of scope

Relates to #1173.

## Verification

- `pnpm nx test:ts server` passed
- `pnpm nx test:eslint server` passed
- Prettier and `git diff --check` passed
- Repository harness checks passed
- Full Vitest was blocked by an unrelated protobuf descriptor build error
- Focused auth runtime tests were blocked by the local PostgreSQL service using port 8432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Customer records now include the authentication method used during registration and authentication, such as SIWE or WebAuthn.
  * Authentication and registration tracking now captures both the authentication method and its source for more detailed analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->