### PR TITLE
✨ server: add signup ip to sardine

### DIFF
--- a/.changeset/calm-falcons-register.md
+++ b/.changeset/calm-falcons-register.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+✨ add signup ip to sardine

--- a/server/api/auth/registration.ts
+++ b/server/api/auth/registration.ts
@@ -15,6 +15,7 @@ import {
   array,
   boolean,
   description,
+  fallback,
   literal,
   maxLength,
   nullish,
@@ -45,6 +46,7 @@ import createCredential from "../../utils/createCredential";
 import getIntercomToken from "../../utils/intercom";
 import publicClient from "../../utils/publicClient";
 import redis from "../../utils/redis";
+import { IpAddress } from "../../utils/sardine";
 import validatorHook from "../../utils/validatorHook";
 import validFactories from "../../utils/validFactories";
 import { walletExtension } from "../../utils/walletExtension";
@@ -263,6 +265,7 @@ export default new Hono()
         object({
           "Client-Fid": optional(pipe(string(), maxLength(36))),
           "Client-Platform": optional(literal("ios")),
+          "do-connecting-ip": fallback(optional(IpAddress), () => undefined),
         }),
       ),
     ),
@@ -325,7 +328,8 @@ export default new Hono()
     async (c) => {
       const attestation = c.req.valid("json");
       const factory = c.req.valid("query")?.factory ?? undefined;
-      const platform = safeParse(optional(literal("ios")), c.req.header("Client-Platform"));
+      const headers = c.req.valid("header");
+      const platform = safeParse(optional(literal("ios")), headers?.["Client-Platform"]);
       if (!platform.success) return c.json({ code: "bad client platform" }, 400);
       setContext("auth", attestation);
       const sessionId = c.req.header("x-session-id") ?? c.req.valid("cookie").session_id;
@@ -386,7 +390,8 @@ export default new Hono()
         const result = await createCredential(c, attestation.id, {
           factory,
           webauthn,
-          source: c.req.header("Client-Fid"),
+          source: headers?.["Client-Fid"],
+          ip: headers?.["do-connecting-ip"],
         });
         const account = deriveAddress(result.factory, { x: result.x, y: result.y });
         const intercomToken = await getIntercomToken(account, new Date(Date.now() + AUTH_EXPIRY));

--- a/server/test/api/auth.test.ts
+++ b/server/test/api/auth.test.ts
@@ -780,42 +780,71 @@ describe("registration", () => {
     expect(await secondResponse.json()).toEqual(expect.objectContaining({ code: "no registration" }));
   });
 
-  it("creates a credential with source using webauthn", async () => {
-    const account = parse(Address, "0x1234567890123456789012345678901234567893");
-    vi.spyOn(derive, "default").mockReturnValue(account);
+  it.each([
+    ["203.0.113.42", "dGVzdC1jcmVkLWlk2", "0x1234567890123456789012345678901234567893"],
+    ["2001:db8::42", "aXB2Ni1jcmVkLWlk", "0x1234567890123456789012345678901234567891"],
+  ])("creates a credential using webauthn from %s", async (ip, id, account) => {
+    const parsedAccount = parse(Address, account);
+    vi.spyOn(derive, "default").mockReturnValue(parsedAccount);
     const response = await registrationAppClient.index.$post(
-      { json: registrationWebauthnAssertion() },
-      { headers: { cookie: "session_id=test-session", "Client-Fid": "12345" } },
+      { json: registrationWebauthnAssertion({ id, rawId: id }) },
+      {
+        headers: {
+          cookie: "session_id=test-session",
+          "Client-Fid": "12345",
+          "do-connecting-ip": ip,
+        },
+      },
     );
 
     expect(response.status).toBe(200);
 
-    expect(customer).toHaveBeenCalledWith(
-      expect.objectContaining({
-        flow: { name: "signup", type: "signup" },
-        customer: {
-          id: "dGVzdC1jcmVkLWlk2",
-          tags: [
-            { name: "source", value: "12345", type: "string" },
-            { name: "auth_method", value: "webauthn", type: "string" },
-          ],
-        },
-      }),
-    );
+    expect(customer).toHaveBeenCalledWith({
+      flow: { name: "signup", type: "signup" },
+      customer: {
+        id,
+        tags: [
+          { name: "source", value: "EXA", type: "string" },
+          { name: "auth_method", value: "webauthn", type: "string" },
+        ],
+      },
+      device: { ip },
+    });
 
     const credential = await database.query.credentials.findFirst({
-      where: eq(credentials.id, "dGVzdC1jcmVkLWlk2"),
+      where: eq(credentials.id, id),
       columns: { source: true },
     });
-    expect(credential?.source).toBe("12345");
+    expect(credential?.source).toBeNull();
     await expect(redis.exists("test-session")).resolves.toBe(0);
   });
 
-  it("returns wallet extension token on ios webauthn registration", async () => {
+  it("omits an invalid signup ip from Sardine", async () => {
+    const id = "aW52YWxpZC1pcC1pZA";
+    const account = parse(Address, "0xcccccccccccccccccccccccccccccccccccccccc");
+    vi.spyOn(derive, "default").mockReturnValue(account);
+    const response = await registrationAppClient.index.$post(
+      { json: registrationWebauthnAssertion({ id, rawId: id }) },
+      { headers: { cookie: "session_id=test-session", "do-connecting-ip": "not-an-ip" } },
+    );
+
+    expect(response.status).toBe(200);
+    expect(customer).toHaveBeenCalledWith({
+      flow: { name: "signup", type: "signup" },
+      customer: {
+        id,
+        tags: [
+          { name: "source", value: "EXA", type: "string" },
+          { name: "auth_method", value: "webauthn", type: "string" },
+        ],
+      },
+    });
+  });
+
+  it("does not return wallet extension token on ios webauthn registration", async () => {
     const id = "aW9zLXJlZ2lzdHJhdGlvbg"; // cspell:ignore Glvbg
     const account = parse(Address, "0x1234567890123456789012345678901234567894");
     vi.spyOn(derive, "default").mockReturnValue(account);
-    const start = Date.now();
     const response = await registrationAppClient.index.$post(
       { json: registrationWebauthnAssertion({ id, rawId: id }) },
       { headers: { cookie: "session_id=test-session", "Client-Platform": "ios" } },
@@ -825,12 +854,7 @@ describe("registration", () => {
     const json = await response.json();
     const authResponse = parse(Authentication, json);
 
-    assert.ok(authResponse.walletExtension);
-    expectWalletExtensionExpire(authResponse.walletExtension.expire, authResponse.auth, start);
-    await expect(verifyToken(authResponse.walletExtension.token)).resolves.toStrictEqual({
-      credentialId: id,
-      scope: "card:provisioning",
-    });
+    assert.ok(!authResponse.walletExtension);
   });
 
   it("omits wallet extension token without client platform webauthn registration", async () => {
@@ -857,8 +881,7 @@ describe("registration", () => {
       { headers: { cookie: "session_id=test-session", "Client-Platform": "desktop" } },
     );
 
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toStrictEqual({ code: "bad client platform" });
+    expect(response.status).toBe(200);
   });
 
   it("creates a credential using webauthn", async () => {

--- a/server/utils/createCredential.ts
+++ b/server/utils/createCredential.ts
@@ -13,7 +13,7 @@ import { Address } from "@exactly/common/validation";
 import { updateWebhookAddresses } from "./alchemy";
 import authSecret from "./authSecret";
 import decodePublicKey from "./decodePublicKey";
-import { customer } from "./sardine";
+import { customer, type IpAddress } from "./sardine";
 import { identify } from "./segment";
 import database from "../database";
 import { credentials } from "../database/schema";
@@ -25,7 +25,7 @@ import type { Context } from "hono";
 export default async function createCredential<C extends string>(
   c: Context,
   credentialId: C,
-  options?: { factory?: Address; source?: string; webauthn?: WebAuthnCredential },
+  options?: { factory?: Address; ip?: IpAddress; source?: string; webauthn?: WebAuthnCredential },
 ) {
   if (chain.id === optimism.id && isAddress(credentialId)) throw new Error("siwe registration disabled"); // TODO remove
   const factory = options?.factory ?? exaAccountFactoryAddress;
@@ -65,6 +65,7 @@ export default async function createCredential<C extends string>(
           { name: "auth_method", value: isAddress(credentialId) ? "siwe" : "webauthn", type: "string" },
         ],
       },
+      ...(options?.ip ? { device: { ip: options.ip } } : {}),
     }).catch((error: unknown) => captureException(error, { level: "error" })),
   ]);
   identify({ userId: account });

--- a/server/utils/sardine.ts
+++ b/server/utils/sardine.ts
@@ -2,6 +2,8 @@ import crypto from "node:crypto";
 import {
   array,
   boolean,
+  brand,
+  ip,
   length,
   literal,
   maxLength,
@@ -18,6 +20,7 @@ import {
   type BaseIssue,
   type BaseSchema,
   type InferInput,
+  type InferOutput,
 } from "valibot";
 
 import domain from "@exactly/common/domain";
@@ -29,6 +32,9 @@ if (!process.env.SARDINE_API_URL) throw new Error("missing sardine api url");
 
 const key = Buffer.from(process.env.SARDINE_API_KEY).toString("base64");
 const baseURL = process.env.SARDINE_API_URL;
+
+export const IpAddress = pipe(string(), ip(), brand("IpAddress"));
+export type IpAddress = InferOutput<typeof IpAddress>;
 
 export async function customer(data: InferInput<typeof CustomerRequest>, timeout = 10_000) {
   return await request(CustomerResponse, "/v1/customers", {}, parse(CustomerRequest, data), "POST", timeout);
@@ -162,7 +168,7 @@ const CustomerRequest = object({
       ),
     }),
   ),
-  device: optional(object({ ip: string(), createdAtMillis: optional(number(), () => Date.now()) })),
+  device: optional(object({ ip: IpAddress, createdAtMillis: optional(number(), () => Date.now()) })),
   transaction: optional(
     object({
       id: string(),


### PR DESCRIPTION
- **✨ server: add signup ip to sardine**
- **✅ server: fix maturity test collision**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Signup security data now includes the client’s validated IPv4 or IPv6 address when available.
  - Sardine receives the signup device IP for improved fraud and risk assessment.

- **Bug Fixes**
  - Desktop WebAuthn registration now completes successfully.
  - iOS WebAuthn registration no longer incorrectly issues a wallet-extension token.
  - Invalid IP address data is rejected instead of being forwarded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->