### PR TITLE
🩹 server: patch siwe signup ip

### DIFF
--- a/.changeset/brisk-otters-forward.md
+++ b/.changeset/brisk-otters-forward.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🩹 patch siwe signup ip


### PR DESCRIPTION
## Summary

- forward the trusted `do-connecting-ip` value to Sardine for first-time SIWE signup
- keep normal login and existing registration behavior unchanged
- cover valid IP forwarding and invalid IP omission

## Verification

- `git diff --check` — passed
- `pnpm exec eslint api/auth/authentication.ts test/api/auth.test.ts --max-warnings=0` — passed
- `pnpm run test:ts` — passed
- `pnpm nx test:openapi server` — passed
- `pnpm exec vitest run test/api/auth.test.ts` — blocked before test discovery by local Postgres initialization failure

The focused Vitest failure is an environment setup issue, not a test assertion failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SIWE signup handling for connecting IP addresses.
  * Invalid IP addresses are now excluded from fraud-prevention checks.
  * Existing-customer sign-ins no longer trigger unnecessary Sardine checks.
* **Tests**
  * Added coverage for valid, invalid, and missing connecting IP address scenarios.
* **Chores**
  * Prepared a patch release for the server package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->