### PR TITLE
🔧 server: enable vitest coverage only in CI

### DIFF
--- a/server/vitest.config.mts
+++ b/server/vitest.config.mts
@@ -6,7 +6,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globalSetup: ["test/anvil.ts", "test/database.ts", "test/redis.ts", "test/spotlight.ts"],
-    coverage: { enabled: true, reporter: ["lcov"] },
+    coverage: { enabled: !!env.CI, reporter: ["lcov"] },
     reporters: ["default", "junit"],
     outputFile: { junit: fileURLToPath(new URL("coverage/junit.xml", import.meta.url)) },
     testTimeout: 36_666,


### PR DESCRIPTION
## what

one-line change in `server/vitest.config.mts`: vitest coverage runs only when `CI` is set. CI behavior is unchanged — github actions sets `CI=true`, so codecov unit reports, the e2e lcov upload, and junit test results all stay exactly as they are.

```diff
-    coverage: { enabled: true, reporter: ["lcov"] },
+    coverage: { enabled: !!env.CI, reporter: ["lcov"] },
```

## why

coverage instrumentation was always on, including local runs, where nobody reads the report. measured on a 2-core vps (same worktree, same node_modules, only the flag differs):

| scenario | coverage on (main) | coverage off | delta |
| --- | --- | --- | --- |
| harness-free set (18 files, 256 tests) | 3:03 | 1:24 | −54% |
| auth api file w/ harness (40 tests) | 1:28 | 1:01 | −30% |
| single light file (statement, 7 tests) | 1:02 | 0:38 | −38% |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Code coverage reporting now runs only in continuous integration environments, while retaining LCOV report generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->