### PR TITLE
🐛 server: disambiguate incremental collection signatures

### DIFF
--- a/.changeset/brave-otters-wander.md
+++ b/.changeset/brave-otters-wander.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🐛 disambiguate incremental collection signatures

--- a/server/hooks/panda.ts
+++ b/server/hooks/panda.ts
@@ -1023,9 +1023,14 @@ async function prepareCollection(
   const amount = BigInt(Math.round(usdAmount * 1e6));
   if (amount === 0n) return { amount, call: null, transaction: null };
   const call = await (async () => {
-    const timestamp = Math.floor(
+    const authorized = Math.floor(
       (payload.body.spend.authorizedAt ? new Date(payload.body.spend.authorizedAt) : new Date()).getTime() / 1000, // TODO remove fallback
     );
+    const timestamp =
+      payload.action === "updated" ||
+      (payload.action === "completed" && amount !== BigInt(Math.round((payload.body.spend.amount / 100) * 1e6)))
+        ? authorized - Number(BigInt(`0x${payload.id.replaceAll(/[^0-9a-f]/g, "")}`) % 3600n)
+        : authorized;
     const signature = await signIssuerOp({ account, amount, timestamp }, issuer); // TODO replace with payload signature
     if (payload.body.spend.signature) {
       await startSpan(
@@ -1059,9 +1064,9 @@ async function prepareCollection(
     if (card.mode === 0) {
       return { functionName: "collectDebit", args: [amount, BigInt(timestamp), signature] } as const;
     }
-    const nextMaturity = timestamp - (timestamp % MATURITY_INTERVAL) + MATURITY_INTERVAL;
+    const nextMaturity = authorized - (authorized % MATURITY_INTERVAL) + MATURITY_INTERVAL;
     const firstMaturity =
-      nextMaturity - timestamp < MIN_BORROW_INTERVAL ? nextMaturity + MATURITY_INTERVAL : nextMaturity;
+      nextMaturity - authorized < MIN_BORROW_INTERVAL ? nextMaturity + MATURITY_INTERVAL : nextMaturity;
     if (card.mode === 1 || usdAmount < card.mode || payload.action === "requested") {
       return {
         functionName: "collectCredit",

--- a/server/test/hooks/panda.test.ts
+++ b/server/test/hooks/panda.test.ts
@@ -766,6 +766,64 @@ describe("card operations", () => {
         });
       });
 
+      it("clears repeated transaction updates", async () => {
+        const amount = 77;
+        const update = 22;
+        const authorizedAt = new Date().toISOString();
+
+        const cardId = "tRepeatedUpdate";
+        await database.insert(cards).values([{ id: cardId, credentialId: "cred", lastFour: "8888", mode: 0 }]);
+        const createResponse = await appClient.index.$post({
+          ...authorization,
+          json: {
+            ...authorization.json,
+            action: "created",
+            body: {
+              ...authorization.json.body,
+              id: cardId,
+              spend: { ...authorization.json.body.spend, cardId, amount, localAmount: amount, authorizedAt },
+            },
+          },
+        });
+
+        const statuses: number[] = [];
+        for (const [index, id] of ["update-first", "update-second"].entries()) {
+          const transaction = await database.query.transactions.findFirst({ where: eq(transactions.id, cardId) });
+          await publicClient.waitForTransactionReceipt({ hash: transaction?.hashes[index] as Hex, confirmations: 0 });
+          const response = await appClient.index.$post({
+            ...authorization,
+            json: {
+              ...authorization.json,
+              id,
+              action: "updated",
+              body: {
+                ...authorization.json.body,
+                id: cardId,
+                spend: {
+                  ...authorization.json.body.spend,
+                  amount: amount + update * (index + 1),
+                  authorizationUpdateAmount: update,
+                  authorizedAt,
+                  cardId,
+                  localAmount: amount + update * (index + 1),
+                },
+              },
+            },
+          });
+          statuses.push(response.status);
+        }
+
+        expect(createResponse.status).toBe(200);
+        expect(statuses).toEqual([200, 200]);
+        expect(captureException).not.toHaveBeenCalled();
+
+        const transaction = await database.query.transactions.findFirst({ where: eq(transactions.id, cardId) });
+
+        expect(transaction).toMatchObject({
+          hashes: [expect.any(String), expect.any(String), expect.any(String)],
+        });
+      });
+
       it("clears installments", async () => {
         const amount = 120;
 
@@ -2071,6 +2129,173 @@ describe("card operations", () => {
         });
         expect(spendFromPayload(transaction?.payload)).toBeDefined();
         expect(spendFromPayload(transaction?.payload, "completed")).toMatchObject({ amount: capture });
+      });
+
+      it("over-captures debit by the authorized amount", async () => {
+        const hold = 27;
+        const capture = 54;
+        const authorizedAt = new Date().toISOString();
+
+        const cardId = "over-capture-double";
+        await database.insert(cards).values([{ id: cardId, credentialId: "cred", lastFour: "8888", mode: 0 }]);
+        const createResponse = await appClient.index.$post({
+          ...authorization,
+          json: {
+            ...authorization.json,
+            action: "created",
+            body: {
+              ...authorization.json.body,
+              id: cardId,
+              spend: { ...authorization.json.body.spend, amount: hold, authorizedAt, cardId, localAmount: hold },
+            },
+          },
+        });
+        const created = await database.query.transactions.findFirst({ where: eq(transactions.id, cardId) });
+        await publicClient.waitForTransactionReceipt({ hash: created?.hashes[0] as Hex, confirmations: 0 });
+
+        const completeResponse = await appClient.index.$post({
+          ...authorization,
+          json: {
+            ...authorization.json,
+            action: "completed",
+            body: {
+              ...authorization.json.body,
+              id: cardId,
+              spend: {
+                ...authorization.json.body.spend,
+                amount: capture,
+                authorizedAmount: hold,
+                authorizedAt,
+                postedAt: new Date().toISOString(),
+                cardId,
+                status: "completed",
+              },
+            },
+          },
+        });
+
+        expect(createResponse.status).toBe(200);
+        expect(completeResponse.status).toBe(200);
+        expect(captureException).not.toHaveBeenCalled();
+
+        const transaction = await database.query.transactions.findFirst({ where: eq(transactions.id, cardId) });
+
+        expect(transaction).toMatchObject({
+          hashes: [expect.any(String), expect.any(String)],
+        });
+        expect(spendFromPayload(transaction?.payload, "completed")).toMatchObject({ amount: capture });
+      });
+
+      it("returns ok on over-capture replay", async () => {
+        const hold = 29;
+        const capture = 58;
+        const authorizedAt = new Date().toISOString();
+
+        const cardId = "over-capture-replay";
+        await database.insert(cards).values([{ id: cardId, credentialId: "cred", lastFour: "8888", mode: 0 }]);
+        const createResponse = await appClient.index.$post({
+          ...authorization,
+          json: {
+            ...authorization.json,
+            action: "created",
+            body: {
+              ...authorization.json.body,
+              id: cardId,
+              spend: { ...authorization.json.body.spend, amount: hold, authorizedAt, cardId, localAmount: hold },
+            },
+          },
+        });
+        const created = await database.query.transactions.findFirst({ where: eq(transactions.id, cardId) });
+        await publicClient.waitForTransactionReceipt({ hash: created?.hashes[0] as Hex, confirmations: 0 });
+
+        const json = {
+          ...authorization.json,
+          action: "completed" as const,
+          body: {
+            ...authorization.json.body,
+            id: cardId,
+            spend: {
+              ...authorization.json.body.spend,
+              amount: capture,
+              authorizedAmount: hold,
+              authorizedAt,
+              postedAt: new Date().toISOString(),
+              cardId,
+              status: "completed" as const,
+            },
+          },
+        };
+        const first = await appClient.index.$post({ ...authorization, json });
+        const completed = await database.query.transactions.findFirst({ where: eq(transactions.id, cardId) });
+        await publicClient.waitForTransactionReceipt({ hash: completed?.hashes[1] as Hex, confirmations: 0 });
+
+        const second = await appClient.index.$post({ ...authorization, json });
+
+        expect(createResponse.status).toBe(200);
+        expect(first.status).toBe(200);
+        expect(second.status).toBe(200);
+        expect(captureException).toHaveBeenCalledExactlyOnceWith(
+          expect.any(BaseError),
+          expect.objectContaining({ level: "error", fingerprint: ["{{ default }}", "Replay"] }),
+        );
+
+        const transaction = await database.query.transactions.findFirst({ where: eq(transactions.id, cardId) });
+
+        expect(transaction).toMatchObject({
+          hashes: [expect.any(String), expect.any(String)],
+        });
+      });
+
+      it("returns ok on force-capture replay", async () => {
+        const amount = 31;
+        const authorizedAt = new Date().toISOString();
+
+        const cardId = "force-capture-replay";
+        await database.insert(cards).values([{ id: cardId, credentialId: "cred", lastFour: "8888", mode: 0 }]);
+        const createResponse = await appClient.index.$post({
+          ...authorization,
+          json: {
+            ...authorization.json,
+            action: "created",
+            body: {
+              ...authorization.json.body,
+              id: cardId,
+              spend: { ...authorization.json.body.spend, amount, authorizedAt, cardId, localAmount: amount },
+            },
+          },
+        });
+        const created = await database.query.transactions.findFirst({ where: eq(transactions.id, cardId) });
+        await publicClient.waitForTransactionReceipt({ hash: created?.hashes[0] as Hex, confirmations: 0 });
+        await database.delete(transactions).where(eq(transactions.id, cardId));
+
+        const completeResponse = await appClient.index.$post({
+          ...authorization,
+          json: {
+            ...authorization.json,
+            action: "completed",
+            body: {
+              ...authorization.json.body,
+              id: cardId,
+              spend: {
+                ...authorization.json.body.spend,
+                amount,
+                authorizedAmount: amount,
+                authorizedAt,
+                postedAt: new Date().toISOString(),
+                cardId,
+                status: "completed",
+              },
+            },
+          },
+        });
+
+        expect(createResponse.status).toBe(200);
+        expect(completeResponse.status).toBe(200);
+        expect(captureException).toHaveBeenCalledExactlyOnceWith(
+          expect.any(BaseError),
+          expect.objectContaining({ level: "error", fingerprint: ["{{ default }}", "Replay"] }),
+        );
+        expect(await database.query.transactions.findFirst({ where: eq(transactions.id, cardId) })).toBeUndefined();
       });
 
       it("partial-captures debit", async () => {


### PR DESCRIPTION
## what

sign transaction updates and over-captures with `authorizedAt - (webhook id % 3600)` instead of the bare `authorizedAt`, mirroring what the refund branch already does. created, force capture and plain settlements keep signing with `authorizedAt`. maturities are still derived from the unmodified `authorizedAt`.


## tests

- `clears repeated transaction updates`: two updates with the same delta on one transaction now both collect
- `over-captures debit by the authorized amount`: over capture equal to the original hold now collects
- `returns ok on over-capture replay`: redelivery of the same completed webhook still replays and returns ok
- `returns ok on force-capture replay`: force capture against an already collected created still replays


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction signature handling to prevent collisions during incremental collection updates.
  * Improved processing of repeated debit updates and partial or over-capture scenarios.
  * Ensured replayed or force-captured transactions return the appropriate replay status without creating duplicate records.
  * Corrected installment maturity timing for authorized collections, including partial captures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->